### PR TITLE
Prevent the loading of unwanted CSS.

### DIFF
--- a/src/js/converter.js
+++ b/src/js/converter.js
@@ -511,6 +511,7 @@ return function(writer) {
                     var aliases = schema.aliases || [];
                     if (schemaUrl == schema.url || $.inArray(schemaUrl, aliases) !== -1) {
                         schemaId = id;
+                        cssFilename = null;
                         return false;
                     }
                 });


### PR DESCRIPTION
Case only comes up when xml-stylesheet occurs before xml-schema.