### PR TITLE
add uri parameter as part of the edit/create entity dialog response

### DIFF
--- a/src/js/cwrcDialogs/cD.js
+++ b/src/js/cwrcDialogs/cD.js
@@ -1415,6 +1415,10 @@ define('cwrcDialogs', ['jquery', 'jquery-ui', 'bootstrap-datepicker'], function 
                         } else {
                             response = cwrcApi[dialogType].newEntity(xml);
                         }
+                        response.uri = repositoryBaseObjectURL + response.pid;
+                        // response needs to include: 
+                        //  = pid{from API} and 
+                        //  = URI
                         var result = {
                             response : response,
                             data : xml

--- a/src/js/dialogManager.js
+++ b/src/js/dialogManager.js
@@ -63,7 +63,8 @@ return function(writer) {
     };
 
     // set URL for CWRC-Dialogs
-    cD.setRepositoryBaseObjectURL('http://cwrc-dev-01.srv.ualberta.ca/islandora/object/');
+    // ToDo - 2015-05-29 - set with a config file
+    cD.setRepositoryBaseObjectURL('http://commons.cwrc.ca/');
 
     // log in for CWRC-Dialogs
 //    cD.initializeWithCookieData(null);

--- a/src/js/dialogs/cwrcDialogBridge.js
+++ b/src/js/dialogs/cwrcDialogBridge.js
@@ -21,7 +21,7 @@ return function(writer, config) {
                 if (result.response !== undefined && result.response.pid !== undefined) {
                     w.dialogManager.show('schema/'+localDialog, {
                         cwrcInfo: {
-                            id: 'http://cwrc-dev-01.srv.ualberta.ca/islandora/object/'+result.response.pid
+                            id: result.response.uri
                         }
                     });
                 } else {


### PR DESCRIPTION
This pull request removes the necessity that the CWRC-Writer build the URI string that is added to the ref attribute in the XML.  The CWRC-Dialog passes this value as part of the response to a edit/create operation.  